### PR TITLE
Remove check for oldskool minitest/unit, this is being phased out

### DIFF
--- a/lib/seatbelt.rb
+++ b/lib/seatbelt.rb
@@ -12,17 +12,9 @@ if defined?(Test)
 end
 
 if defined?(Minitest)
-  if Minitest::Unit::VERSION[0].to_i < 5
-    class Minitest::Unit::TestCase
-      include Seatbelt::AssertContentType if defined?(ActionController)
-      include AssertJson
-      include Seatbelt::AssertMail if defined?(ActionMailer)
-    end
-  else
-    class Minitest::Test
-      include Seatbelt::AssertContentType if defined?(ActionController)
-      include AssertJson
-      include Seatbelt::AssertMail if defined?(ActionMailer)
-    end
+  class Minitest::Test
+    include Seatbelt::AssertContentType if defined?(ActionController)
+    include AssertJson
+    include Seatbelt::AssertMail if defined?(ActionMailer)
   end
 end


### PR DESCRIPTION
### 📝 Description

It is 'ancient' and the minitest gem will no longer load minitest/unit by default: https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6